### PR TITLE
Drop a handful of test cases from the proposed gating set of tests

### DIFF
--- a/cases/gating.only
+++ b/cases/gating.only
@@ -32,7 +32,6 @@ virsh.vcpupin.online.positive_test.cpu_list.cpu_list_comma
 virsh.vcpupin.online.positive_test.live
 virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.running_guest.emulatorpin_options.current
 virsh.setvcpus.normal_test.guest_off.option_config
-virsh.schedinfo_qemu_posix.normal_test.set_cpu_param.set_cpu_shares.value_exceed.set_by_cmd.config.valid_domid
 
 # numa
 guest_numa.possitive_test.no_hugepage.mem_backend.topology.no_numatune_memnode.no_numatune_mem

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -92,7 +92,6 @@ virsh.managedsave.functional_test.saved_file
 virsh.secret_define_undefine.normal_test.non_acl.ephemeral_yes
 
 # other commands
-virsh.domjobabort.normal_test.dump_option.live_dump.running_option.id_option
 virsh.dommemstat.normal_test.id_option
 virsh.domstate.normal_test.name_option
 virsh.domstats.normal_test.domain_state.active.option.cpu_total.default_print.not_enforce.specific_domain

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -97,7 +97,6 @@ virsh.secret_define_undefine.normal_test.non_acl.ephemeral_yes
 # other commands
 virsh.domiftune.positive_testing.get_domif_parameter.running_guest.options.current
 virsh.blkdeviotune.positive_testing.set_blkdevio_parameter.running_guest.change_read_bytes_sec.options.config.inside_boundary
-virsh.domdisplay.have_passwd.no_options.positive_readonly.vnc_t.domain_uuid
 virsh.dominfo.normal_test.id_option
 virsh.domjobabort.normal_test.dump_option.live_dump.running_option.id_option
 virsh.dommemstat.normal_test.id_option
@@ -105,4 +104,3 @@ virsh.domstate.normal_test.name_option
 virsh.domstats.normal_test.domain_state.active.option.cpu_total.default_print.not_enforce.specific_domain
 virsh.dump.positive_test.non_acl.bzip2_format_dump
 virsh.freecell.libvirtoff.expected_options.expected_args_0
-virsh.vncdisplay.normal_test.name_option

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -42,9 +42,6 @@ libvirt_mem.positive_test.with_source
 # memory baloon
 virsh.setmem.valid_options.running.half_mem.domid.dom_arg_size_arg.cmd_flag_current.manipulate_action.none.no_action
 
-# block jobs
-virsh.domblkstat.normal_test.human_option
-
 # svirt
 svirt_attach_disk.positive_test.default_vol.domain_seclabel.disk_label_svirt_image_s0.sec_relabel_yes.sec_type_dynamic
 dac_nfs_disk.positive_test.nfs_img_qemu.qemu_user.dynamic_ownership_off.no_root_squash
@@ -53,8 +50,6 @@ dac_nfs_disk.positive_test.nfs_img_qemu.qemu_user.dynamic_ownership_off.no_root_
 virsh.snapshot.live.no_halt
 
 # storage
-virsh.vol_create_from.positive_test.dest_vol_format.v_qcow2.src_vol_format.v_qcow2.dest_pool_type.dir.src_pool_type.dir
-virsh.vol_create.create.positive_test.disk_pool.vol_format_linux.pool_format_none.non_encryption
 virsh.volume.dir_pool.vol_encrypt_none.vol_format_qcow2.vol_allocation.normal_size
 virsh.pool.positive_test.pool_type_dir
 
@@ -66,7 +61,6 @@ virsh.update_device.normal_test.config_option.scsi_option
 
 # virtual network
 virsh.domiflist.with_valid_option.domid
-virsh.domifstat.normal_test.id_option
 virsh.net_create.normal_test.file_as_argument.new_network
 virsh.net_destroy.normal_test.non_acl.default_option.persistent
 virsh.net_list.normal_test.non_acl.all_opt
@@ -76,7 +70,4 @@ virsh.net_start.normal_test.non_acl.valid_netname
 virsh.managedsave.functional_test.saved_file
 
 # other commands
-virsh.dommemstat.normal_test.id_option
-virsh.domstate.normal_test.name_option
-virsh.domstats.normal_test.domain_state.active.option.cpu_total.default_print.not_enforce.specific_domain
 virsh.dump.positive_test.non_acl.bzip2_format_dump

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -42,10 +42,6 @@ libvirt_mem.positive_test.with_source
 # memory baloon
 virsh.setmem.valid_options.running.half_mem.domid.dom_arg_size_arg.cmd_flag_current.manipulate_action.none.no_action
 
-# svirt
-svirt_attach_disk.positive_test.default_vol.domain_seclabel.disk_label_svirt_image_s0.sec_relabel_yes.sec_type_dynamic
-dac_nfs_disk.positive_test.nfs_img_qemu.qemu_user.dynamic_ownership_off.no_root_squash
-
 # snapshot
 virsh.snapshot.live.no_halt
 

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -21,9 +21,6 @@ virsh.resume.normal_test.vm_paused.valid_domname
 virsh.restore.expected_option.non_acl.no_option
 virsh.save.normal_test.normal_option.no_option.no_progress
 
-# undefine
-virsh.undefine.normal_test.vm_running.no_option
-
 # reset
 virsh.reset.positive_test.non_acl.name_options
 

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -28,9 +28,6 @@ libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.save
 libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.managedsave
 
 # cpu feature
-virsh.cpu_baseline.positive_test.default_test
-virsh.cpu_models.positive_test.local_host.auto_get_arch
-virsh.maxvcpus.connect_to_local.no_option
 virsh.vcpucount.positive_tests.running_test.live_active_option
 virsh.vcpupin.online.positive_test.cpu_list.cpu_list_comma
 virsh.vcpupin.online.positive_test.live
@@ -87,4 +84,3 @@ virsh.dommemstat.normal_test.id_option
 virsh.domstate.normal_test.name_option
 virsh.domstats.normal_test.domain_state.active.option.cpu_total.default_print.not_enforce.specific_domain
 virsh.dump.positive_test.non_acl.bzip2_format_dump
-virsh.freecell.libvirtoff.expected_options.expected_args_0

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -59,7 +59,6 @@ virsh.update_device.normal_test.config_option.scsi_option
 virsh.domiflist.with_valid_option.domid
 virsh.net_create.normal_test.file_as_argument.new_network
 virsh.net_destroy.normal_test.non_acl.default_option.persistent
-virsh.net_list.normal_test.non_acl.all_opt
 virsh.net_start.normal_test.non_acl.valid_netname
 
 # managed save

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -83,7 +83,6 @@ virsh.domiflist.with_valid_option.domid
 virsh.domifstat.normal_test.id_option
 virsh.net_create.normal_test.file_as_argument.new_network
 virsh.net_destroy.normal_test.non_acl.default_option.persistent
-virsh.net_edit.net_define.modify.changeable
 virsh.net_info.normal_test.name_option
 virsh.net_list.normal_test.non_acl.all_opt
 virsh.net_start.normal_test.non_acl.valid_netname

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -28,7 +28,6 @@ libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.save
 libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.managedsave
 
 # cpu feature
-virsh.vcpucount.positive_tests.running_test.live_active_option
 virsh.vcpupin.online.positive_test.cpu_list.cpu_list_comma
 virsh.vcpupin.online.positive_test.live
 virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.running_guest.emulatorpin_options.current

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -41,7 +41,6 @@ libvirt_mem.positive_test.with_source
 
 # memory feature
 virsh.memtune.positive_test.step_increment
-virsh.setmaxmem.normal_test.config.running.same_mem.domname.dom_arg_size_arg
 virsh.setmem.valid_options.running.half_mem.domid.dom_arg_size_arg.cmd_flag_current.manipulate_action.none.no_action
 
 # block jobs

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -106,5 +106,4 @@ virsh.domstate.normal_test.name_option
 virsh.domstats.normal_test.domain_state.active.option.cpu_total.default_print.not_enforce.specific_domain
 virsh.dump.positive_test.non_acl.bzip2_format_dump
 virsh.freecell.libvirtoff.expected_options.expected_args_0
-virsh.metadata.positive_test.current_option
 virsh.vncdisplay.normal_test.name_option

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -92,8 +92,6 @@ virsh.managedsave.functional_test.saved_file
 virsh.secret_define_undefine.normal_test.non_acl.ephemeral_yes
 
 # other commands
-virsh.domiftune.positive_testing.get_domif_parameter.running_guest.options.current
-virsh.blkdeviotune.positive_testing.set_blkdevio_parameter.running_guest.change_read_bytes_sec.options.config.inside_boundary
 virsh.domjobabort.normal_test.dump_option.live_dump.running_option.id_option
 virsh.dommemstat.normal_test.id_option
 virsh.domstate.normal_test.name_option

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -56,7 +56,6 @@ virsh.setmaxmem.normal_test.config.running.same_mem.domname.dom_arg_size_arg
 virsh.setmem.valid_options.running.half_mem.domid.dom_arg_size_arg.cmd_flag_current.manipulate_action.none.no_action
 
 # block jobs
-virsh.domblkinfo.normal_test.id_option
 virsh.domblkstat.normal_test.human_option
 
 # svirt
@@ -83,7 +82,6 @@ virsh.domiflist.with_valid_option.domid
 virsh.domifstat.normal_test.id_option
 virsh.net_create.normal_test.file_as_argument.new_network
 virsh.net_destroy.normal_test.non_acl.default_option.persistent
-virsh.net_info.normal_test.name_option
 virsh.net_list.normal_test.non_acl.all_opt
 virsh.net_start.normal_test.non_acl.valid_netname
 
@@ -96,7 +94,6 @@ virsh.secret_define_undefine.normal_test.non_acl.ephemeral_yes
 # other commands
 virsh.domiftune.positive_testing.get_domif_parameter.running_guest.options.current
 virsh.blkdeviotune.positive_testing.set_blkdevio_parameter.running_guest.change_read_bytes_sec.options.config.inside_boundary
-virsh.dominfo.normal_test.id_option
 virsh.domjobabort.normal_test.dump_option.live_dump.running_option.id_option
 virsh.dommemstat.normal_test.id_option
 virsh.domstate.normal_test.name_option

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -39,8 +39,7 @@ guest_numa.possitive_test.no_hugepage.mem_backend.topology.no_numatune_memnode.n
 # memory hotplug
 libvirt_mem.positive_test.with_source
 
-# memory feature
-virsh.memtune.positive_test.step_increment
+# memory baloon
 virsh.setmem.valid_options.running.half_mem.domid.dom_arg_size_arg.cmd_flag_current.manipulate_action.none.no_action
 
 # block jobs

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -88,9 +88,6 @@ virsh.net_start.normal_test.non_acl.valid_netname
 # managed save
 virsh.managedsave.functional_test.saved_file
 
-# secret
-virsh.secret_define_undefine.normal_test.non_acl.ephemeral_yes
-
 # other commands
 virsh.dommemstat.normal_test.id_option
 virsh.domstate.normal_test.name_option

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -84,7 +84,6 @@ virsh.domifstat.normal_test.id_option
 virsh.net_autostart.normal_test.set_autostart.netname
 virsh.net_create.normal_test.file_as_argument.new_network
 virsh.net_destroy.normal_test.non_acl.default_option.persistent
-virsh.net_dumpxml.normal_test.non_acl.name_option
 virsh.net_edit.net_define.modify.changeable
 virsh.net_info.normal_test.name_option
 virsh.net_list.normal_test.non_acl.all_opt
@@ -106,7 +105,6 @@ virsh.dommemstat.normal_test.id_option
 virsh.domstate.normal_test.name_option
 virsh.domstats.normal_test.domain_state.active.option.cpu_total.default_print.not_enforce.specific_domain
 virsh.dump.positive_test.non_acl.bzip2_format_dump
-virsh.dumpxml.normal_test.non_acl.vm_running.with_default.domid
 virsh.freecell.libvirtoff.expected_options.expected_args_0
 virsh.metadata.positive_test.current_option
 virsh.vncdisplay.normal_test.name_option

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -21,9 +21,6 @@ virsh.resume.normal_test.vm_paused.valid_domname
 virsh.restore.expected_option.non_acl.no_option
 virsh.save.normal_test.normal_option.no_option.no_progress
 
-# reset
-virsh.reset.positive_test.non_acl.name_options
-
 # cpu hotplug
 libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.save
 

--- a/cases/gating.only
+++ b/cases/gating.only
@@ -81,7 +81,6 @@ virsh.update_device.normal_test.config_option.scsi_option
 # virtual network
 virsh.domiflist.with_valid_option.domid
 virsh.domifstat.normal_test.id_option
-virsh.net_autostart.normal_test.set_autostart.netname
 virsh.net_create.normal_test.file_as_argument.new_network
 virsh.net_destroy.normal_test.non_acl.default_option.persistent
 virsh.net_edit.net_define.modify.changeable


### PR DESCRIPTION
This PR drops a handful of test cases from the gating list because they're either not useful for gating purposes at all or not useful in their given form (which parameters they have enabled). After this PR we have roughly the base set for testing libvirt core functionality (of course more tuning in terms of parameters will be needed) except for migration which we still need to introduce in the test suite, however, a migration test will take a much longer time but it's something we must introduce at some point.